### PR TITLE
Add reference utils reference for ios10 fix

### DIFF
--- a/index.ios.js
+++ b/index.ios.js
@@ -1,4 +1,5 @@
 var frameModule = require("ui/frame");
+var utils = require("utils/utils");
 
 var CustomMFMessageComposeViewControllerDelegate = NSObject.extend({    
     initWithResolveReject: function(resolve, reject) {


### PR DESCRIPTION
The code is missing the reference to "utils/utils" from tns-core-modules
